### PR TITLE
Set endTime = startTime in FoxgloveWebSocketPlayer disconnected states

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -905,6 +905,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
     if (!this.#endTime || isGreaterThan(currentTime, this.#endTime)) {
       this.#endTime = currentTime;
     }
+    if (this.#presence !== PlayerPresence.PRESENT) {
+      this.#endTime = this.#startTime;
+    }
 
     const messages = this.#parsedMessages;
     this.#parsedMessages = [];


### PR DESCRIPTION
**User-Facing Changes**
- Extension panels can detect WebSocket disconnected states by checking if `endTime == undefined || endTime == startTime`

**Description**
This sets endTime equal to startTime in the FoxgloveWebSocketPlayer when the socket is in a disconnected state. The internal API defines the endTime type as `Time` instead of `Time | undefined`, otherwise undefined would probably make more sense here.