### PR TITLE
System Uptime in AppBar

### DIFF
--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -7,6 +7,7 @@ import { CircularProgress, IconButton } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
+import { Uptime } from "@foxglove/studio-base/components/AppBar/Uptime";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -119,6 +120,7 @@ export function DataSource(): JSX.Element {
             <>
               <span>/</span>
               <EndTimestamp />
+              <Uptime />
             </>
           )}
         </div>

--- a/packages/studio-base/src/components/AppBar/Uptime.tsx
+++ b/packages/studio-base/src/components/AppBar/Uptime.tsx
@@ -10,7 +10,6 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
-import { formatDuration } from "@foxglove/studio-base/util/formatTime";
 
 const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;

--- a/packages/studio-base/src/components/AppBar/Uptime.tsx
+++ b/packages/studio-base/src/components/AppBar/Uptime.tsx
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useTheme } from "@mui/material";
+import moment from "moment";
+import { useEffect, useRef } from "react";
+
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { formatDuration } from "@foxglove/studio-base/util/formatTime";
+
+const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
+
+export function Uptime(): JSX.Element | ReactNull {
+  const startTime = useMessagePipeline(selectStartTime);
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const theme = useTheme();
+
+  const timeRef = useRef<HTMLDivElement>(ReactNull);
+
+  // We bypass react and update the DOM elements directly for better performance here.
+  useEffect(() => {
+    if (!timeRef.current) {
+      return;
+    }
+    if (startTime == undefined) {
+      timeRef.current.innerText = "";
+      return;
+    }
+
+    const uptimeSec = (currentTime?.sec ?? 0) - startTime.sec;
+    const uptimeFormatted = formatDurationCustom(uptimeSec * 1000); // milliseconds
+
+    timeRef.current.innerText = `(${uptimeFormatted})`;
+  }, [startTime, currentTime]);
+
+  return (
+    <div
+      style={{ fontFeatureSettings: `${theme.typography.fontFeatureSettings}, "zero"` }}
+      ref={timeRef}
+    />
+  );
+}
+
+function formatDurationCustom(duration: number) {
+  // Create a duration object from the given milliseconds
+  const dur = moment.duration(duration);
+
+  // Build the format string based on the duration values
+  let formatString = "";
+  if (dur.hours() > 0) {
+    formatString += "h[h] ";
+  }
+  if (dur.hours() > 0 || dur.minutes() > 0) {
+    formatString += "m[m] ";
+  }
+  formatString += "s[s]";
+
+  // Format and return the duration string
+  return dur.format(formatString.trim());
+}

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -301,6 +301,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#supportedEncodings = event.supportedEncodings;
       this.#datatypes = new Map();
 
+      // systemStartTime will be NaN if no value or unparseable
+      const systemStartTime: number = parseInt(event.metadata?.["systemStartTime"] ?? "");
+      if (!isNaN(systemStartTime)) {
+        this.#startTime = { sec: systemStartTime, nsec: 0 };
+      }
+
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override
       if (this.#serverPublishesTime) {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -301,10 +301,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#supportedEncodings = event.supportedEncodings;
       this.#datatypes = new Map();
 
-      // systemStartTime will be NaN if no value or unparseable
-      const systemStartTime: number = parseInt(event.metadata?.["systemStartTime"] ?? "");
-      if (!isNaN(systemStartTime)) {
-        this.#startTime = { sec: systemStartTime, nsec: 0 };
+      // serverStartTime will be NaN if no value or unparseable
+      const serverStartTime: number = parseInt(event.metadata?.["startTime"] ?? "");
+      if (!isNaN(serverStartTime)) {
+        this.#startTime = { sec: serverStartTime, nsec: 0 };
       }
 
       // If the server publishes the time we clear any existing clockTime we might have and let the


### PR DESCRIPTION
**Description**

`FoxgloveWebSocketPlayer` now looks for a `systemStartTime` entry on `serverInfo` events. This is used to show the uptime of the system next to the current timestamp in the AppBar.