### PR TITLE
Support foxglove.CompressedAnnotateImage messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxglove-studio",
-  "version": "1.87.0-dev",
+  "version": "1.90.0",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@3.6.3",

--- a/packages/studio-base/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete/Autocomplete.tsx
@@ -139,16 +139,21 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
   }, [items]);
 
   const fzf = useMemo(() => {
-    return new Fzf(items, {
-      // v1 algorithm is significantly faster on long lists of items.
-      fuzzy: items.length > FAST_FIND_ITEM_CUTOFF ? "v1" : "v2",
-      sort: sortWhenFiltering,
-      limit: MAX_FZF_MATCHES,
-    });
+    try {
+      return new Fzf(items, {
+        // v1 algorithm is significantly faster on long lists of items.
+        fuzzy: items.length > FAST_FIND_ITEM_CUTOFF ? "v1" : "v2",
+        sort: sortWhenFiltering,
+        limit: MAX_FZF_MATCHES,
+      });
+    } catch (e) {
+      console.error(`Error creating Fzf instance: ${e}`);
+      return undefined;
+    }
   }, [items, sortWhenFiltering]);
 
   const autocompleteItems = useMemo(() => {
-    return filterText ? fzf.find(filterText) : fzfUnfiltered;
+    return filterText && fzf ? fzf.find(filterText) : fzfUnfiltered;
   }, [filterText, fzf, fzfUnfiltered]);
 
   const hasError = props.hasError ?? (autocompleteItems.length === 0 && value?.length !== 0);

--- a/packages/studio-base/src/components/Autocomplete/fzf.test.ts
+++ b/packages/studio-base/src/components/Autocomplete/fzf.test.ts
@@ -1,0 +1,20 @@
+import { Fzf } from "fzf";
+
+describe("fzf", () => {
+  it("does fuzzy searching", () => {
+    const fzf = new Fzf(["apple", "banana", "cherry"], { fuzzy: "v1" });
+    const resA = fzf.find("a");
+    expect(resA).toHaveLength(2);
+    const resA0 = resA[0]!;
+    const resA1 = resA[1]!;
+    expect(resA0.start).toBe(0);
+    expect(resA0.end).toBe(1);
+    expect(resA0.item).toBe("apple");
+    expect(resA1.start).toBe(1);
+    expect(resA1.end).toBe(2);
+    expect(resA1.item).toBe("banana");
+
+    expect(fzf.find("b")).toHaveLength(1);
+    expect(fzf.find("c")).toHaveLength(1);
+  });
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
@@ -20,6 +20,9 @@ addFoxgloveSchema(RAW_IMAGE_DATATYPES, "foxglove.RawImage");
 export const COMPRESSED_IMAGE_DATATYPES = new Set<string>();
 addFoxgloveSchema(COMPRESSED_IMAGE_DATATYPES, "foxglove.CompressedImage");
 
+export const COMPRESSED_ANNOTATED_IMAGE_DATATYPES = new Set<string>();
+addFoxgloveSchema(COMPRESSED_ANNOTATED_IMAGE_DATATYPES, "foxglove.CompressedAnnotatedImage");
+
 export const CAMERA_CALIBRATION_DATATYPES = new Set<string>();
 addFoxgloveSchema(CAMERA_CALIBRATION_DATATYPES, "foxglove.CameraCalibration");
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -25,10 +25,12 @@ import {
 import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import {
   AnyImage,
+  CompressedAnnotatedImage,
   getTimestampFromImage,
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/Images/ImageTypes";
 import {
   normalizeCompressedImage,
+  normalizeCompressedAnnotatedImage,
   normalizeRawImage,
   normalizeRosCompressedImage,
   normalizeRosImage,
@@ -200,6 +202,23 @@ export class MessageHandler implements IMessageHandler {
 
   public handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
     this.handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
+  };
+
+  public handleCompressedAnnotatedImage = (
+    messageEvent: PartialMessageEvent<CompressedAnnotatedImage>,
+  ): void => {
+    const normalized = normalizeCompressedAnnotatedImage(messageEvent.message);
+    const annotationsEvent = {
+      topic: messageEvent.topic,
+      schemaName: "foxglove.ImageAnnotations",
+      receiveTime: messageEvent.receiveTime,
+      publishTime: messageEvent.publishTime,
+      message: normalized.annotations,
+      sizeInBytes: messageEvent.sizeInBytes,
+      originalMessageEvent: messageEvent,
+    };
+    this.handleAnnotations(annotationsEvent);
+    this.handleImage(messageEvent, normalized);
   };
 
   protected handleImage(message: PartialMessageEvent<AnyImage>, image: AnyImage): void {
@@ -449,6 +468,9 @@ export interface IMessageHandler {
   handleRosCompressedImage: (messageEvent: PartialMessageEvent<RosCompressedImage>) => void;
   handleRawImage: (messageEvent: PartialMessageEvent<RawImage>) => void;
   handleCompressedImage: (messageEvent: PartialMessageEvent<CompressedImage>) => void;
+  handleCompressedAnnotatedImage: (
+    messageEvent: PartialMessageEvent<CompressedAnnotatedImage>,
+  ) => void;
   handleCameraInfo: (message: PartialMessageEvent<CameraInfo>) => void;
   handleAnnotations: (
     messageEvent: MessageEvent<FoxgloveImageAnnotations | RosImageMarker | RosImageMarkerArray>,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/normalizeAnnotations.ts
@@ -249,4 +249,4 @@ function getAnnotationAtPath(message: unknown, path: PathKey[]): RosObject {
   return value as RosObject;
 }
 
-export { normalizeAnnotations, getAnnotationAtPath };
+export { normalizeAnnotations, normalizeFoxgloveImageAnnotations, getAnnotationAtPath };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { Time } from "@foxglove/rostime";
-import { CompressedImage, RawImage } from "@foxglove/schemas";
+import { CompressedImage, ImageAnnotations, RawImage } from "@foxglove/schemas";
 import { CAMERA_CALIBRATION_DATATYPES } from "@foxglove/studio-base/panels/ThreeDeeRender/foxglove";
 
 import {
@@ -16,12 +16,25 @@ export const ALL_CAMERA_INFO_SCHEMAS = new Set([
   ...CAMERA_CALIBRATION_DATATYPES,
 ]);
 
-export type CompressedImageTypes = RosCompressedImage | CompressedImage;
+/** A compressed image with annotations */
+export type CompressedAnnotatedImage = {
+  image: CompressedImage;
+  annotations: ImageAnnotations;
+};
 
-export type AnyImage = RosImage | RosCompressedImage | RawImage | CompressedImage;
+export type CompressedImageTypes = RosCompressedImage | CompressedImage | CompressedAnnotatedImage;
+
+export type AnyImage =
+  | RosImage
+  | RosCompressedImage
+  | RawImage
+  | CompressedImage
+  | CompressedAnnotatedImage;
 
 export function getFrameIdFromImage(image: AnyImage): string {
-  if ("header" in image) {
+  if ("image" in image) {
+    return getFrameIdFromImage(image.image);
+  } else if ("header" in image) {
     return image.header.frame_id;
   } else {
     return image.frame_id;
@@ -29,7 +42,9 @@ export function getFrameIdFromImage(image: AnyImage): string {
 }
 
 export function getTimestampFromImage(image: AnyImage): Time {
-  if ("header" in image) {
+  if ("image" in image) {
+    return getTimestampFromImage(image.image);
+  } else if ("header" in image) {
     return image.header.stamp;
   } else {
     return image.timestamp;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -29,6 +29,9 @@ export async function decodeCompressedImageToBitmap(
   image: CompressedImageTypes,
   resizeWidth?: number,
 ): Promise<ImageBitmap> {
+  if ("image" in image) {
+    return await decodeCompressedImageToBitmap(image.image, resizeWidth);
+  }
   const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
   return await createImageBitmap(bitmapData, { resizeWidth });
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/imageNormalizers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/imageNormalizers.ts
@@ -2,8 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { CompressedImage, RawImage } from "@foxglove/schemas";
+import { CompressedImage, ImageAnnotations, RawImage } from "@foxglove/schemas";
 import { PartialMessage } from "@foxglove/studio-base/panels/ThreeDeeRender/SceneExtension";
+import { CompressedAnnotatedImage } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/Images/ImageTypes";
 
 import { normalizeByteArray, normalizeHeader, normalizeTime } from "../../normalizeMessages";
 import { Image as RosImage, CompressedImage as RosCompressedImage } from "../../ros";
@@ -63,5 +64,19 @@ export function normalizeCompressedImage(
     frame_id: message.frame_id ?? "",
     format: message.format ?? "",
     data: normalizeByteArray(message.data),
+  };
+}
+
+export function normalizeCompressedAnnotatedImage(
+  message: PartialMessage<CompressedAnnotatedImage>,
+): CompressedAnnotatedImage {
+  const annotations = (message.annotations ?? {
+    circles: [],
+    points: [],
+    texts: [],
+  }) as ImageAnnotations;
+  return {
+    image: normalizeCompressedImage(message.image ?? {}),
+    annotations,
   };
 }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.87.0-dev",
+  "version": "1.90.0-dev",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
* `foxglove.CompressedAnnotatedImage` messages are supported in the Image and 3D panels
* Mitigates a crash from the Fzf library not being bundled properly in CI. The root cause is TBD
* Bumps sviz version to 1.90.0
