### PR TITLE
Add TLS support to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY <<EOF /etc/caddy/Caddyfile
 }
 
 {env.ROBOT_NAME}.{env.DOMAIN_NAME} {
-    tls /etc/ssl/{env.ROBOT_NAME}.{env.DOMAIN_NAME} /etc/ssl/{env.ROBOT_NAME}.{env.DOMAIN_NAME}.key
+    tls /etc/ssl/cert.crt /etc/ssl/cert.key
     root * /app
     file_server
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,24 @@ RUN yarn install --immutable
 RUN yarn run web:build:prod
 
 # Release stage
-FROM caddy:2.6.4-alpine
+FROM caddy:2.9.1-alpine
 WORKDIR /app
 COPY --from=build /src/web/.webpack ./
 
-EXPOSE 80
+EXPOSE 80 443
+
+# Configure Caddy with HTTP to HTTPS redirect and TLS
+COPY <<EOF /etc/caddy/Caddyfile
+:80 {
+    redir https://{env.ROBOT_NAME}.{env.DOMAIN_NAME}{uri} permanent
+}
+
+{env.ROBOT_NAME}.{env.DOMAIN_NAME} {
+    tls /etc/ssl/{env.ROBOT_NAME}.{env.DOMAIN_NAME} /etc/ssl/{env.ROBOT_NAME}.{env.DOMAIN_NAME}.key
+    root * /app
+    file_server
+}
+EOF
 
 COPY <<EOF /entrypoint.sh
 # Optionally override the default layout with one provided via bind mount
@@ -37,4 +50,4 @@ exec "\$@"
 EOF
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
-CMD ["caddy", "file-server", "--listen", ":80"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
This PR introduces TLS support in the `Dockerfile`. This includes upgrading the Caddy server version, configuring HTTPS, and updating the Caddy server command.

Improvements to web server setup:

* Upgraded Caddy server from version `2.6.4-alpine` to `2.9.1-alpine` to leverage new features and security improvements.
* Added configuration for Caddy to redirect HTTP traffic to HTTPS and set up TLS using environment variables for domain and certificate paths.
* Exposed port 443 in addition to port 80 to support HTTPS traffic.
* Updated the Caddy server command to use the new configuration file and adapter, replacing the old file-server command.