### PR TITLE
Update Dockerfile.ci, publish commit hash docker tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,public=true
+            type=sha,format=long,public=true
 
       - name: Configure QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,11 +1,24 @@
-FROM caddy:2.6.4-alpine
+FROM caddy:2.9.1-alpine
 WORKDIR /app
 
 # Copy index.html first to fail fast if it's missing
 COPY web/.webpack/index.html ./index.html
 COPY web/.webpack ./
 
-EXPOSE 80
+EXPOSE 80 443
+
+# Configure Caddy with HTTP to HTTPS redirect and TLS
+COPY <<EOF /etc/caddy/Caddyfile
+:80 {
+    redir https://{env.ROBOT_NAME}.{env.DOMAIN_NAME}{uri} permanent
+}
+
+{env.ROBOT_NAME}.{env.DOMAIN_NAME} {
+    tls /etc/ssl/cert.crt /etc/ssl/cert.key
+    root * /app
+    file_server
+}
+EOF
 
 COPY <<EOF /entrypoint.sh
 # Optionally override the default layout with one provided via bind mount
@@ -29,4 +42,4 @@ exec "\$@"
 EOF
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
-CMD ["caddy", "file-server", "--listen", ":80"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
Updates to Docker setup:

* Update `Dockerfile.ci` to match `Dockerfile` TLS changes

Updates to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR159): Added a new tagging format to include the long SHA of the commit for better traceability.