### PR TITLE
Default WebSocket connections to wss://

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,7 @@ FROM caddy:2.9.1-alpine
 WORKDIR /app
 COPY --from=build /src/web/.webpack ./
 
-EXPOSE 80 443
-
-# Configure Caddy with HTTP to HTTPS redirect and TLS
-COPY <<EOF /etc/caddy/Caddyfile
-:80 {
-    redir https://{env.ROBOT_NAME}.{env.DOMAIN_NAME}{uri} permanent
-}
-
-{env.ROBOT_NAME}.{env.DOMAIN_NAME} {
-    tls /etc/ssl/cert.crt /etc/ssl/cert.key
-    root * /app
-    file_server
-}
-EOF
+EXPOSE 80
 
 COPY <<EOF /entrypoint.sh
 # Optionally override the default layout with one provided via bind mount
@@ -50,4 +37,4 @@ exec "\$@"
 EOF
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+CMD ["caddy", "file-server", "--listen", ":80"]

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -1403,7 +1403,7 @@ function statusLevelToProblemSeverity(level: StatusLevel): PlayerProblem["severi
 
 // Converts shorthand and fully qualified WebSocket URLs to a normalized form
 export function normalizeWsUrl(input: string): string {
-  const defaultScheme = "ws://";
+  const defaultScheme = "wss://";
   const defaultPort = "8765";
   let scheme = defaultScheme;
   let port = defaultPort;


### PR DESCRIPTION
You still need to enter a FQDN for SSL websockets to work, but this removes the need to add the `wss://` prefix since we assume all robot websocket connections are via TLS moving forward. To connect to a non-TLS websocket such as a development server use an explicit `ws://` prefix.